### PR TITLE
Fix chat with wins and settings modal

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -106,11 +106,32 @@
                     </div>
                     <div class="form-group">
                         <label for="model">Model</label>
-                        <input type="text" id="model" name="model" value="moonshotai/kimi-dev-72b:free" required>
+                        <select id="model" name="model" required></select>
                     </div>
                     <button type="submit" class="btn btn-primary">Save Settings</button>
                 </form>
             </div>
+        </div>
+    </div>
+
+    <!-- Chat Modal -->
+    <div id="chatModal" class="modal hidden" role="dialog" aria-labelledby="chatModalTitle" aria-modal="true" aria-hidden="true">
+        <div class="modal__backdrop"></div>
+        <div class="modal__content">
+            <div class="modal__header">
+                <h2 id="chatModalTitle" class="modal__title">Chat with Wins</h2>
+                <button id="chatModalClose" class="modal__close" aria-label="Close chat modal dialog">
+                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                        <line x1="18" y1="6" x2="6" y2="18"></line>
+                        <line x1="6" y1="6" x2="18" y2="18"></line>
+                    </svg>
+                </button>
+            </div>
+            <div id="chatMessages" class="chat-messages"></div>
+            <form id="chatForm" class="chat-form">
+                <input type="text" id="chatInput" placeholder="Type your message..." required>
+                <button type="submit" class="btn btn-primary">Send</button>
+            </form>
         </div>
     </div>
 

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -1352,95 +1352,6 @@ summary:focus {
     cursor: pointer;
     z-index: 1000;
 }
-/* Settings Modal */
-#settingsModal {
-    display: none;
-    position: fixed;
-    z-index: 1000;
-    left: 0;
-    top: 0;
-    width: 100%;
-    height: 100%;
-    overflow: auto;
-    background-color: rgba(0,0,0,0.4);
-}
-
-#settingsModal .modal__content {
-    background-color: #fefefe;
-    margin: 15% auto;
-    padding: 20px;
-    border: 1px solid #888;
-    width: 80%;
-    max-width: 600px;
-}
-
-#settingsModal .modal__header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-}
-
-#settingsModal .modal__close {
-    color: #aaa;
-    font-size: 28px;
-    font-weight: bold;
-}
-
-#settingsModal .modal__close:hover,
-#settingsModal .modal__close:focus {
-    color: black;
-    text-decoration: none;
-    cursor: pointer;
-}
-
-#settingsModal .form-group {
-    margin-bottom: 15px;
-}
-
-#settingsModal label {
-    display: block;
-    margin-bottom: 5px;
-}
-
-#settingsModal input[type=text] {
-    width: 100%;
-    padding: 12px 20px;
-    margin: 8px 0;
-    display: inline-block;
-    border: 1px solid #ccc;
-    box-sizing: border-box;
-}
-
-#settingsModal button {
-    background-color: #007bff;
-    color: white;
-    padding: 14px 20px;
-    margin: 8px 0;
-    border: none;
-    cursor: pointer;
-    width: 100%;
-}
-
-#settingsModal button:hover {
-    opacity: 0.8;
-}
-
-body.modal-open {
-    overflow: hidden;
-}
-
-/* Settings button */
-#settingsBtn {
-    position: fixed;
-    top: 10px;
-    right: 10px;
-    padding: 10px;
-    background-color: #007bff;
-    color: white;
-    border: none;
-    cursor: pointer;
-    z-index: 1000;
-}
 /* Settings button */
 #settingsBtn {
     position: fixed;
@@ -1513,7 +1424,8 @@ body.modal-open {
     margin-bottom: 5px;
 }
 
-#settingsModal input[type=text] {
+#settingsModal input[type=text],
+#settingsModal select {
     width: 100%;
     padding: 12px 20px;
     margin: 8px 0;
@@ -1540,12 +1452,26 @@ body.modal-open {
     overflow: hidden;
 }
 
-/* Settings button */
-#settingsBtn {
-    padding: 10px;
-    background-color: #007bff;
-    color: white;
-    border: none;
-    cursor: pointer;
-    z-index: 1000;
+/* Chat modal styles */
+#chatModal .chat-messages {
+    max-height: 60vh;
+    overflow-y: auto;
+    margin-bottom: 1rem;
+}
+
+#chatModal .chat-message {
+    margin-bottom: 0.5rem;
+}
+
+#chatModal .chat-message.user {
+    text-align: right;
+}
+
+#chatModal .chat-form {
+    display: flex;
+    gap: 0.5rem;
+}
+
+#chatModal .chat-form input {
+    flex: 1;
 }


### PR DESCRIPTION
## Summary
- Add dropdown model selection and new chat modal for "Chat with Wins".
- Populate model list from OpenRouter, persist settings, and enable chatting against win notes.
- Clean up CSS so settings modal displays correctly and style new chat interface.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f5323e7348326882ee414a4bdb0a5