### PR TITLE
Enhance chat with wins

### DIFF
--- a/frontend/style.css
+++ b/frontend/style.css
@@ -1461,10 +1461,30 @@ body.modal-open {
 
 #chatModal .chat-message {
     margin-bottom: 0.5rem;
+    padding: 0.5rem 0.75rem;
+    border-radius: 8px;
+    line-height: 1.4;
+    white-space: pre-wrap;
 }
 
 #chatModal .chat-message.user {
     text-align: right;
+    background-color: #007bff;
+    color: #fff;
+}
+
+#chatModal .chat-message.assistant {
+    background-color: #f1f1f1;
+    color: #000;
+}
+
+#chatModal .chat-message.system {
+    font-style: italic;
+    color: #555;
+}
+
+#chatModal .chat-message.error {
+    color: red;
 }
 
 #chatModal .chat-form {


### PR DESCRIPTION
## Summary
- Stream chat responses from OpenRouter and render incrementally
- Use win notes JSON as retrieval context for user queries
- Style chat messages with bubbles and preserved line breaks for easier reading

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f5892f3b88326b3792d70c023a5d5