### PR TITLE
fix: ensure win notes load in UI and chat

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -4,6 +4,9 @@ let filteredNotes = [];
 let searchTimeout = null;
 let activeFilter = 'all';
 
+// Path to win notes data
+const WIN_NOTES_URL = './win_notes.json';
+
 // DOM elements - will be set after DOM loads
 let searchInput, resultsGrid, emptyState, resultsCount, modal, modalTitle, modalBody, modalClose, filterChips;
 
@@ -31,7 +34,7 @@ function init() {
     bindEvents();
 
     // Load data and initialize
-    fetch('win_notes.json')
+    fetch(WIN_NOTES_URL)
         .then(res => res.json())
         .then(data => {
             allNotes = data;
@@ -572,7 +575,7 @@ document.addEventListener('DOMContentLoaded', function() {
                     chatMessages.innerHTML = '<div class="chat-message system">Win notes loaded. How can I help?</div>';
                 } else {
                     try {
-                        winNotesData = await fetch('win_notes.json').then(r => r.json());
+                        winNotesData = await fetch(WIN_NOTES_URL).then(r => r.json());
                         chatHistory = [{ role: 'system', content: 'You are a helpful assistant. Use the provided win notes to answer questions about Nutanix wins.' }];
                         chatMessages.innerHTML = '<div class="chat-message system">Win notes loaded. How can I help?</div>';
                     } catch (err) {


### PR DESCRIPTION
## Summary
- use a shared URL constant for win note data
- reference that constant when loading data for the grid and chat

## Testing
- `node --check frontend/app.js`
- `python -m json.tool frontend/win_notes.json >/dev/null`


------
https://chatgpt.com/codex/tasks/task_e_688f6903dd0c8326824a4d3b933a26e8