### PR TITLE
fix: remove duplicate win notes url

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -6,9 +6,6 @@ let activeFilter = 'all';
 let winNotesData = [];
 
 // Path to win notes data
-const WIN_NOTES_URL = 'win_notes.json';
-
-// Path to win notes data
 const WIN_NOTES_URL = './win_notes.json';
 
 // DOM elements - will be set after DOM loads


### PR DESCRIPTION
## Summary
- remove duplicate definition for `WIN_NOTES_URL` in app.js so script can load

## Testing
- `node --check frontend/app.js`


------
https://chatgpt.com/codex/tasks/task_e_688f7dd72f548326915fc70dd6681400