### PR TITLE
Enhance Screening Room with improved drag, TV/VCR, and 3D effects

### DIFF
--- a/screening-room/index.html
+++ b/screening-room/index.html
@@ -46,6 +46,16 @@
             display: flex;
             flex-direction: column;
             gap: 60px;
+            position: relative;
+        }
+
+        .tv-vcr {
+            position: absolute;
+            top: -20px;
+            right: 0;
+            width: 250px;
+            height: 200px;
+            z-index: 10;
         }
 
         .shelf {
@@ -54,6 +64,14 @@
             height: 250px;
             transform-style: preserve-3d;
             transform: rotateX(15deg);
+        }
+
+        .shelf[data-shelf="0"] {
+            height: 180px;
+        }
+
+        .shelf[data-shelf="0"] .shelf-slots {
+            height: 150px;
         }
 
         .shelf-base {
@@ -133,6 +151,8 @@
             cursor: grabbing;
             z-index: 1000;
             animation: pulseGlow 0.8s ease-in-out infinite;
+            transform: none !important;
+            transform-style: flat !important;
         }
 
         @keyframes pulseGlow {
@@ -150,45 +170,78 @@
 
         .box-face {
             position: absolute;
-            border: 2px solid currentColor;
+            border: 2.5px solid currentColor;
             background: currentColor;
-            opacity: 0.3;
+            opacity: 0.15;
+            box-shadow: inset 0 0 20px currentColor;
         }
 
         .box-front {
             width: 80px;
             height: 120px;
             transform: translateZ(40px);
+            border-width: 3px;
+            opacity: 0.25;
         }
 
         .box-back {
             width: 80px;
             height: 120px;
             transform: translateZ(-40px) rotateY(180deg);
+            opacity: 0.1;
         }
 
         .box-left {
             width: 80px;
             height: 120px;
             transform: rotateY(-90deg) translateZ(40px);
+            opacity: 0.12;
         }
 
         .box-right {
             width: 80px;
             height: 120px;
             transform: rotateY(90deg) translateZ(40px);
+            opacity: 0.18;
         }
 
         .box-top {
             width: 80px;
             height: 80px;
             transform: rotateX(90deg) translateZ(40px);
+            opacity: 0.2;
         }
 
         .box-bottom {
             width: 80px;
             height: 80px;
             transform: rotateX(-90deg) translateZ(80px);
+            opacity: 0.08;
+        }
+
+        /* Add perspective lines/edges to emphasize 3D structure */
+        .box::before {
+            content: '';
+            position: absolute;
+            width: 2px;
+            height: 120px;
+            background: currentColor;
+            left: 0;
+            top: 0;
+            transform: translateZ(40px);
+            opacity: 0.6;
+        }
+
+        .box::after {
+            content: '';
+            position: absolute;
+            width: 2px;
+            height: 120px;
+            background: currentColor;
+            right: 0;
+            top: 0;
+            transform: translateZ(40px);
+            opacity: 0.6;
         }
 
         .controls {
@@ -235,6 +288,43 @@
     <h1>The Screening Room</h1>
 
     <div class="container">
+        <svg class="tv-vcr" viewBox="0 0 250 200" xmlns="http://www.w3.org/2000/svg">
+            <!-- TV Screen -->
+            <rect x="20" y="20" width="210" height="130" fill="none" stroke="#00d4ff" stroke-width="2.5"/>
+            <rect x="30" y="30" width="190" height="110" fill="rgba(0, 212, 255, 0.05)" stroke="#a855f7" stroke-width="1.5"/>
+
+            <!-- Screen glare effect -->
+            <line x1="35" y1="35" x2="75" y2="75" stroke="rgba(0, 212, 255, 0.3)" stroke-width="1.5"/>
+            <line x1="35" y1="45" x2="60" y2="70" stroke="rgba(0, 212, 255, 0.2)" stroke-width="1"/>
+
+            <!-- VCR Section -->
+            <rect x="20" y="155" width="210" height="35" fill="none" stroke="#00d4ff" stroke-width="2.5"/>
+
+            <!-- VCR Slot -->
+            <rect x="40" y="165" width="80" height="15" fill="rgba(0, 0, 0, 0.5)" stroke="#a855f7" stroke-width="1.5"/>
+
+            <!-- VCR Buttons -->
+            <circle cx="140" cy="172.5" r="5" fill="none" stroke="#00d4ff" stroke-width="1.5"/>
+            <circle cx="160" cy="172.5" r="5" fill="none" stroke="#00d4ff" stroke-width="1.5"/>
+            <circle cx="180" cy="172.5" r="5" fill="none" stroke="#00d4ff" stroke-width="1.5"/>
+            <circle cx="200" cy="172.5" r="5" fill="none" stroke="#a855f7" stroke-width="1.5"/>
+
+            <!-- Play triangle in button -->
+            <polygon points="158,170 158,175 163,172.5" fill="#00d4ff" opacity="0.6"/>
+
+            <!-- TV antenna -->
+            <line x1="125" y1="20" x2="105" y2="-5" stroke="#00d4ff" stroke-width="2"/>
+            <line x1="125" y1="20" x2="145" y2="-5" stroke="#a855f7" stroke-width="2"/>
+            <circle cx="105" cy="-5" r="3" fill="#00d4ff"/>
+            <circle cx="145" cy="-5" r="3" fill="#a855f7"/>
+
+            <!-- Control knobs on side -->
+            <circle cx="235" cy="50" r="6" fill="none" stroke="#00d4ff" stroke-width="1.5"/>
+            <circle cx="235" cy="70" r="6" fill="none" stroke="#a855f7" stroke-width="1.5"/>
+            <line x1="235" y1="50" x2="239" y2="46" stroke="#00d4ff" stroke-width="1.5"/>
+            <line x1="235" y1="70" x2="239" y2="74" stroke="#a855f7" stroke-width="1.5"/>
+        </svg>
+
         <div class="shelf" data-shelf="0">
             <div class="shelf-base"></div>
             <div class="shelf-slots">
@@ -365,19 +455,23 @@
 
             originalSlot = draggedBox.slot;
             originalShelf = draggedBox.shelf;
-            box.classList.add('dragging');
 
-            const rect = box.getBoundingClientRect();
             const clientX = e.clientX || e.touches[0].clientX;
             const clientY = e.clientY || e.touches[0].clientY;
 
-            dragOffset.x = clientX - rect.left;
-            dragOffset.y = clientY - rect.top;
+            // Get the box position before adding dragging class
+            const rect = box.getBoundingClientRect();
 
-            // Immediately position the box at its current location in fixed coordinates
+            // Calculate offset from mouse to box center
+            dragOffset.x = rect.left + rect.width / 2 - clientX;
+            dragOffset.y = rect.top + rect.height / 2 - clientY;
+
+            box.classList.add('dragging');
+
+            // Immediately position the box centered on the cursor
             box.style.position = 'fixed';
-            box.style.left = (rect.left) + 'px';
-            box.style.top = (rect.top) + 'px';
+            box.style.left = (clientX + dragOffset.x) + 'px';
+            box.style.top = (clientY + dragOffset.y) + 'px';
             box.style.zIndex = '1000';
 
             document.addEventListener('mousemove', drag);
@@ -395,8 +489,8 @@
 
             const box = draggedBox.element;
             box.style.position = 'fixed';
-            box.style.left = (clientX - dragOffset.x) + 'px';
-            box.style.top = (clientY - dragOffset.y) + 'px';
+            box.style.left = (clientX + dragOffset.x) + 'px';
+            box.style.top = (clientY + dragOffset.y) + 'px';
             box.style.zIndex = '1000';
         }
 


### PR DESCRIPTION
- Fix drag positioning to keep box exactly under cursor during drag
- Add retro line-art TV/VCR illustration in top right corner
- Make top shelf shorter to accommodate TV/VCR graphic
- Enhance 3D box appearance with line perspective effect
- Add wireframe-style boxes with varying opacity per face
- Emphasize depth with stronger borders and edge lines
- Disable transforms during dragging for accurate positioning