### PR TITLE
Refine top shelf layout and enhance 3D box thickness

### DIFF
--- a/screening-room/index.html
+++ b/screening-room/index.html
@@ -51,10 +51,10 @@
 
         .tv-vcr {
             position: absolute;
-            top: -20px;
+            top: 0px;
             right: 0;
-            width: 250px;
-            height: 200px;
+            width: 550px;
+            height: 400px;
             z-index: 10;
         }
 
@@ -70,8 +70,15 @@
             height: 180px;
         }
 
+        .shelf[data-shelf="0"] .shelf-base {
+            width: 35%;
+            left: 5%;
+        }
+
         .shelf[data-shelf="0"] .shelf-slots {
             height: 150px;
+            width: 35%;
+            left: 5%;
         }
 
         .shelf-base {
@@ -145,6 +152,7 @@
             transition: transform 0.3s ease, filter 0.3s ease;
             cursor: grab;
             user-select: none;
+            filter: drop-shadow(0 4px 8px rgba(0, 0, 0, 0.3));
         }
 
         .box.dragging {
@@ -179,7 +187,7 @@
         .box-front {
             width: 80px;
             height: 120px;
-            transform: translateZ(40px);
+            transform: translateZ(60px);
             border-width: 3px;
             opacity: 0.25;
         }
@@ -187,19 +195,19 @@
         .box-back {
             width: 80px;
             height: 120px;
-            transform: translateZ(-40px) rotateY(180deg);
+            transform: translateZ(-60px) rotateY(180deg);
             opacity: 0.1;
         }
 
         .box-left {
-            width: 80px;
+            width: 120px;
             height: 120px;
             transform: rotateY(-90deg) translateZ(40px);
             opacity: 0.12;
         }
 
         .box-right {
-            width: 80px;
+            width: 120px;
             height: 120px;
             transform: rotateY(90deg) translateZ(40px);
             opacity: 0.18;
@@ -207,15 +215,15 @@
 
         .box-top {
             width: 80px;
-            height: 80px;
-            transform: rotateX(90deg) translateZ(40px);
+            height: 120px;
+            transform: rotateX(90deg) translateZ(60px);
             opacity: 0.2;
         }
 
         .box-bottom {
             width: 80px;
-            height: 80px;
-            transform: rotateX(-90deg) translateZ(80px);
+            height: 120px;
+            transform: rotateX(-90deg) translateZ(60px);
             opacity: 0.08;
         }
 
@@ -223,25 +231,25 @@
         .box::before {
             content: '';
             position: absolute;
-            width: 2px;
+            width: 3px;
             height: 120px;
             background: currentColor;
             left: 0;
             top: 0;
-            transform: translateZ(40px);
-            opacity: 0.6;
+            transform: translateZ(60px);
+            opacity: 0.7;
         }
 
         .box::after {
             content: '';
             position: absolute;
-            width: 2px;
+            width: 3px;
             height: 120px;
             background: currentColor;
             right: 0;
             top: 0;
-            transform: translateZ(40px);
-            opacity: 0.6;
+            transform: translateZ(60px);
+            opacity: 0.7;
         }
 
         .controls {
@@ -330,10 +338,6 @@
             <div class="shelf-slots">
                 <div class="slot" data-slot="0" data-shelf="0"></div>
                 <div class="slot" data-slot="1" data-shelf="0"></div>
-                <div class="slot" data-slot="2" data-shelf="0"></div>
-                <div class="slot" data-slot="3" data-shelf="0"></div>
-                <div class="slot" data-slot="4" data-shelf="0"></div>
-                <div class="slot" data-slot="5" data-shelf="0"></div>
             </div>
         </div>
         <div class="shelf" data-shelf="1">


### PR DESCRIPTION
- Reduce top shelf to 2 slots (35% width) to prevent TV overlap
- Enlarge TV/VCR graphic to 550px width to fill right side
- Position TV and shelf to avoid visual overlap
- Increase 3D box depth from 80px to 120px for thicker appearance
- Enhance side faces with 120px depth for better 3D effect
- Strengthen edge lines (3px) and increase opacity for emphasis
- Add shadow for improved depth perception