### PR TITLE
Fix Spider Solitaire card display and difficulty selection bugs

### DIFF
--- a/learning/examples/22-spider-solitaire.html
+++ b/learning/examples/22-spider-solitaire.html
@@ -220,7 +220,7 @@
         /* Cards */
         .card {
             width: 100%;
-            height: 120px;
+            height: 140px;
             background: white;
             border-radius: 8px;
             position: absolute;
@@ -565,7 +565,7 @@
             }
 
             .card {
-                height: 100px;
+                height: 120px;
                 font-size: 14px;
             }
 
@@ -617,7 +617,7 @@
             }
 
             .card {
-                height: 80px;
+                height: 100px;
                 padding: 5px;
                 font-size: 12px;
             }
@@ -891,15 +891,21 @@
             const deck = [];
             const suitsToUse = SUIT_NAMES.slice(0, game.difficulty);
 
-            // Create 2 full decks (104 cards)
-            for (let deckNum = 0; deckNum < 2; deckNum++) {
+            // Calculate how many complete sets of suits we need to reach 104 cards
+            // 1 suit: 8 sets of 13 = 104 cards
+            // 2 suits: 4 sets of 13 each = 104 cards
+            // 4 suits: 2 sets of 13 each = 104 cards
+            const setsNeeded = 8 / game.difficulty;
+
+            // Create the required number of suit sets to get exactly 104 cards
+            for (let setNum = 0; setNum < setsNeeded; setNum++) {
                 for (let suit of suitsToUse) {
                     for (let rank of RANKS) {
                         deck.push({
                             rank,
                             suit,
                             faceUp: false,
-                            id: `${suit}-${rank}-${deckNum}-${Math.random()}`
+                            id: `${suit}-${rank}-${setNum}-${Math.random()}`
                         });
                     }
                 }


### PR DESCRIPTION
Fixed two critical issues in Spider Solitaire:

1. Card Height - Cards were too short (120px) causing content overflow
   - Desktop: Increased to 140px (was 120px)
   - Tablet (@media 1200px): Increased to 120px (was 100px)
   - Mobile (@media 768px): Increased to 100px (was 80px)
   - Card faces now display properly with correct spacing

2. Difficulty Selection - Easy and Medium modes were broken
   - Root cause: createDeck() wasn't creating enough cards
   - Previous: Only created 2 deck iterations regardless of difficulty
     * 1 suit: 2 × 13 = 26 cards (need 104!)
     * 2 suits: 2 × 2 × 13 = 52 cards (need 104!) * 4 suits: 2 × 4 × 13 = 104 cards ✓
   - Fixed: Calculate correct number of suit sets for 104 cards * 1 suit (Easy): 8 sets × 13 = 104 cards * 2 suits (Medium): 4 sets × 2 suits × 13 = 104 cards * 4 suits (Hard): 2 sets × 4 suits × 13 = 104 cards
   - All difficulty levels now work correctly

The deck creation formula: setsNeeded = 8 / difficulty
- Creates exactly 104 cards for all three difficulty modes
- Maintains proper Spider Solitaire game requirements (54 tableau + 50 stock)