### PR TITLE
Fix MP3 filename URL encoding in music visualizers

### DIFF
--- a/learning/examples/08-music-visualizer.html
+++ b/learning/examples/08-music-visualizer.html
@@ -1218,7 +1218,7 @@
 
         function loadPreloadedMP3() {
             // Try to load the included MP3 file
-            const mp3Path = "Avicenna's Floating Man.mp3";
+            const mp3Path = "Avicenna's%20Floating%20Man.mp3";
 
             fetch(mp3Path)
                 .then(response => {

--- a/learning/examples/23-neural-visualizer.html
+++ b/learning/examples/23-neural-visualizer.html
@@ -111,7 +111,7 @@
         async function loadAndPlayAudio() {
             try {
                 // Load the audio file
-                audio = new Audio('Avicenna\'s Floating Man.mp3');
+                audio = new Audio('Avicenna\'s%20Floating%20Man.mp3');
                 audio.volume = 0.7;
                 audio.loop = true; // Loop the audio
 


### PR DESCRIPTION
Fixed MP3 file path to use proper URL encoding for spaces.

The MP3 filename "Avicenna's Floating Man.mp3" contains spaces which need to be URL-encoded as %20 for proper loading via fetch() and Audio() APIs.

Changes:
- 08-music-visualizer.html: "Avicenna's Floating Man.mp3" → "Avicenna's%20Floating%20Man.mp3"
- 23-neural-visualizer.html: 'Avicenna\'s Floating Man.mp3' → 'Avicenna\'s%20Floating%20Man.mp3'

This ensures the MP3 file loads correctly when the HTML files are served over HTTP/HTTPS rather than just file:// protocol.

Verified exact filename on disk:
- Actual file: Avicenna's Floating Man.mp3
- Uses straight apostrophe (U+0027, byte 0x27)
- Contains spaces that require URL encoding