### PR TITLE
Fix async/await issue in music visualizer MP3 loading

### DIFF
--- a/learning/examples/08-music-visualizer.html
+++ b/learning/examples/08-music-visualizer.html
@@ -1260,7 +1260,7 @@
                 } catch (err) {
                     console.log(`Failed to load from ${mp3Path}:`, err.message);
                     // Try next path
-                    tryLoadMP3(paths, index + 1);
+                    await tryLoadMP3(paths, index + 1);
                 }
             }
 


### PR DESCRIPTION
Fixed missing await keyword in recursive tryLoadMP3 call that was preventing the fallback MP3 loading from working correctly.

Issue: The tryLoadMP3 async function was calling itself recursively in the catch block without await, causing the promise chain to break and preventing fallback paths from being tried.

Fix: Added await keyword when recursively calling tryLoadMP3(paths, index + 1) in the catch block, ensuring proper async flow and fallback behavior.

The music visualizer (example 08) now correctly tries all three MP3 paths in sequence until one succeeds.