### PR TITLE
Remove UI elements from visualizers and apply audio fixes to neural v…

### DIFF
--- a/learning/examples/08-music-visualizer.html
+++ b/learning/examples/08-music-visualizer.html
@@ -930,10 +930,6 @@
     </div>
 
     <div class="container">
-        <header>
-            <h1 id="mainTitle">🎵 PRO MUSIC VISUALIZER STUDIO</h1>
-        </header>
-
         <div class="canvas-container">
             <canvas id="visualizer"></canvas>
             <canvas id="threeCanvas"></canvas>
@@ -955,9 +951,7 @@
                     <input type="file" id="audioFile" accept="audio/*" multiple>
                 </label>
                 <button class="btn" id="playlistBtn" onclick="togglePlaylist()">📋 Playlist (<span id="playlistCount">0</span>)</button>
-                <button class="btn" id="micBtn" onclick="toggleMicrophone()">🎤 Microphone</button>
                 <button class="btn" id="playBtn" onclick="togglePlayPause()">▶️ Play</button>
-                <button class="btn btn-small" onclick="takeScreenshot()">📸 Screenshot</button>
             </div>
 
             <div class="control-group mode-selector">

--- a/learning/examples/23-neural-visualizer.html
+++ b/learning/examples/23-neural-visualizer.html
@@ -106,6 +106,13 @@
                 analyser.connect(gainNode);
                 gainNode.connect(audioContext.destination);
             }
+
+            // Resume audio context if it's suspended (browser autoplay policy)
+            if (audioContext && audioContext.state === 'suspended') {
+                audioContext.resume().catch(err => {
+                    console.error('Failed to resume audio context:', err);
+                });
+            }
         }
 
         async function loadAndPlayAudio() {
@@ -163,6 +170,11 @@
                 // Wait for user interaction to start audio (browser requirement)
                 const startAudio = async () => {
                     try {
+                        // Resume audio context if suspended
+                        if (audioContext && audioContext.state === 'suspended') {
+                            await audioContext.resume();
+                        }
+
                         await audio.play();
                         if (!animationId) {
                             animate();
@@ -178,6 +190,11 @@
 
                 // Try to autoplay, but if it fails due to browser policy, wait for user interaction
                 try {
+                    // Resume audio context if suspended
+                    if (audioContext.state === 'suspended') {
+                        await audioContext.resume();
+                    }
+
                     await audio.play();
                     if (!animationId) {
                         animate();


### PR DESCRIPTION
…isualizer

Example 08 (Music Visualizer) - UI Cleanup:
- Removed header with title '🎵 PRO MUSIC VISUALIZER STUDIO'
- Removed microphone button (🎤 Microphone)
- Removed screenshot button (📸 Screenshot)
- Cleaner, more minimal interface focused on core functionality

Example 23 (Neural Visualizer) - Audio Playback Fix: Applied the same AudioContext resume fixes from example 08:

1. Resume AudioContext in initAudioContext():
   - Checks if audioContext.state === 'suspended'
   - Calls audioContext.resume() to activate audio output

2. Resume before autoplay attempt:
   - Resumes AudioContext before calling audio.play()
   - Ensures audio can actually play through Web Audio API

3. Resume on user interaction:
   - If autoplay fails, waits for user click/touch/keypress
   - Resumes AudioContext before attempting playback
   - Guarantees audio works after user interaction

Both visualizers now:
- Have cleaner, more focused UIs (example 08)
- Properly handle browser autoplay policies (example 23)
- Resume suspended AudioContext before playing audio
- Work consistently across all browsers