### PR TITLE
Fix autoplay and visualization rendering in music visualizers

### DIFF
--- a/learning/examples/08-music-visualizer.html
+++ b/learning/examples/08-music-visualizer.html
@@ -1712,6 +1712,11 @@
 
             document.getElementById('uploadArea').classList.add('hidden');
 
+            // Start animation immediately so visualization appears even without audio
+            if (!animationId) {
+                animate();
+            }
+
             // Resume audio context and try to play
             const playAudio = async () => {
                 try {
@@ -1723,10 +1728,6 @@
                     await audio.play();
                     isPlaying = true;
                     document.getElementById('playBtn').textContent = '⏸️ Pause';
-
-                    if (!animationId) {
-                        animate();
-                    }
                 } catch (err) {
                     console.error('Error playing audio:', err);
                     isPlaying = false;
@@ -1741,9 +1742,6 @@
                             await audio.play();
                             isPlaying = true;
                             document.getElementById('playBtn').textContent = '⏸️ Pause';
-                            if (!animationId) {
-                                animate();
-                            }
                             // Remove listeners after successful play
                             document.removeEventListener('click', startOnInteraction);
                             document.removeEventListener('keydown', startOnInteraction);
@@ -1761,7 +1759,10 @@
                 }
             };
 
-            playAudio();
+            // Wait for audio to load before attempting to play
+            audio.addEventListener('canplaythrough', () => {
+                playAudio();
+            }, { once: true });
         }
 
         async function toggleMicrophone() {

--- a/learning/examples/23-neural-visualizer.html
+++ b/learning/examples/23-neural-visualizer.html
@@ -188,21 +188,26 @@
                     }
                 };
 
-                // Try to autoplay, but if it fails due to browser policy, wait for user interaction
-                try {
-                    // Resume audio context if suspended
-                    if (audioContext.state === 'suspended') {
-                        await audioContext.resume();
-                    }
+                // Function to attempt autoplay after audio is ready
+                const attemptAutoplay = async () => {
+                    try {
+                        // Resume audio context if suspended
+                        if (audioContext.state === 'suspended') {
+                            await audioContext.resume();
+                        }
 
-                    await audio.play();
-                } catch (err) {
-                    // Autoplay blocked - wait for user interaction
-                    console.log('Autoplay blocked. Click, touch, or press any key to start.');
-                    document.addEventListener('click', startAudio);
-                    document.addEventListener('touchstart', startAudio);
-                    document.addEventListener('keydown', startAudio);
-                }
+                        await audio.play();
+                    } catch (err) {
+                        // Autoplay blocked - wait for user interaction
+                        console.log('Autoplay blocked. Click, touch, or press any key to start.');
+                        document.addEventListener('click', startAudio);
+                        document.addEventListener('touchstart', startAudio);
+                        document.addEventListener('keydown', startAudio);
+                    }
+                };
+
+                // Wait for audio to be ready before attempting to play
+                audio.addEventListener('canplaythrough', attemptAutoplay, { once: true });
             } catch (err) {
                 console.error('Error setting up audio:', err);
             }


### PR DESCRIPTION
Example 08 (Music Visualizer):
- Fixed autoplay by waiting for 'canplaythrough' event before attempting to play
- Fixed particles effect not showing on load by starting animation immediately
- Visualization now appears instantly even before audio plays
- Audio plays automatically once loaded and ready

Example 23 (Neural Visualizer):
- Fixed audio not autoplaying by waiting for 'canplaythrough' event
- Audio now plays automatically once fully loaded and buffered