### PR TITLE
Fix play button functionality in both visualizers

### DIFF
--- a/learning/examples/08-music-visualizer.html
+++ b/learning/examples/08-music-visualizer.html
@@ -1761,6 +1761,26 @@
                 animate();
             }
 
+            // Set up play overlay click handler immediately
+            const playOverlay = document.getElementById('playOverlay');
+            const startOnOverlayClick = async () => {
+                try {
+                    if (audioContext.state === 'suspended') {
+                        await audioContext.resume();
+                    }
+                    await audio.play();
+                    isPlaying = true;
+                    document.getElementById('playBtn').textContent = '⏸️ Pause';
+                    playOverlay.classList.add('hidden');
+                } catch (e) {
+                    console.error('Could not play:', e);
+                }
+            };
+
+            if (playOverlay) {
+                playOverlay.onclick = startOnOverlayClick;
+            }
+
             // Resume audio context and try to play
             const playAudio = async () => {
                 try {
@@ -1773,7 +1793,6 @@
                     isPlaying = true;
                     document.getElementById('playBtn').textContent = '⏸️ Pause';
                     // Hide play overlay on successful play
-                    const playOverlay = document.getElementById('playOverlay');
                     if (playOverlay) {
                         playOverlay.classList.add('hidden');
                     }
@@ -1783,31 +1802,14 @@
                     document.getElementById('playBtn').textContent = '▶️ Play';
 
                     // Show play overlay if autoplay is blocked
-                    const playOverlay = document.getElementById('playOverlay');
                     if (playOverlay) {
                         playOverlay.classList.remove('hidden');
-
-                        // Add click/touch handler to play overlay
-                        const startOnOverlayClick = async () => {
-                            try {
-                                if (audioContext.state === 'suspended') {
-                                    await audioContext.resume();
-                                }
-                                await audio.play();
-                                isPlaying = true;
-                                document.getElementById('playBtn').textContent = '⏸️ Pause';
-                                playOverlay.classList.add('hidden');
-                            } catch (e) {
-                                console.error('Still could not play:', e);
-                            }
-                        };
-
-                        playOverlay.onclick = startOnOverlayClick;
                     }
                 }
             };
 
-            // Try to play immediately when audio is ready
+            // Load the audio and try to play when ready
+            audio.load();
             audio.addEventListener('canplaythrough', () => {
                 playAudio();
             }, { once: true });

--- a/learning/examples/23-neural-visualizer.html
+++ b/learning/examples/23-neural-visualizer.html
@@ -220,23 +220,23 @@
                 audioSource = audioContext.createMediaElementSource(audio);
                 audioSource.connect(analyser);
 
-                // Wait for user interaction to start audio (browser requirement)
-                const startAudio = async () => {
+                // Set up play overlay click handler immediately
+                const playOverlay = document.getElementById('playOverlay');
+                const startOnOverlayClick = async () => {
                     try {
-                        // Resume audio context if suspended
-                        if (audioContext && audioContext.state === 'suspended') {
+                        if (audioContext.state === 'suspended') {
                             await audioContext.resume();
                         }
-
                         await audio.play();
-                        // Remove the click listener after starting
-                        document.removeEventListener('click', startAudio);
-                        document.removeEventListener('touchstart', startAudio);
-                        document.removeEventListener('keydown', startAudio);
-                    } catch (err) {
-                        console.error('Error playing audio:', err);
+                        playOverlay.classList.add('hidden');
+                    } catch (e) {
+                        console.error('Could not play:', e);
                     }
                 };
+
+                if (playOverlay) {
+                    playOverlay.onclick = startOnOverlayClick;
+                }
 
                 // Function to attempt autoplay after audio is ready
                 const attemptAutoplay = async () => {
@@ -249,31 +249,14 @@
                         await audio.play();
 
                         // Hide play overlay on successful play
-                        const playOverlay = document.getElementById('playOverlay');
                         if (playOverlay) {
                             playOverlay.classList.add('hidden');
                         }
                     } catch (err) {
                         // Autoplay blocked - show play overlay
                         console.log('Autoplay blocked. Click play button to start.');
-                        const playOverlay = document.getElementById('playOverlay');
                         if (playOverlay) {
                             playOverlay.classList.remove('hidden');
-
-                            // Add click/touch handler to play overlay
-                            const startOnOverlayClick = async () => {
-                                try {
-                                    if (audioContext.state === 'suspended') {
-                                        await audioContext.resume();
-                                    }
-                                    await audio.play();
-                                    playOverlay.classList.add('hidden');
-                                } catch (e) {
-                                    console.error('Still could not play:', e);
-                                }
-                            };
-
-                            playOverlay.onclick = startOnOverlayClick;
                         }
                     }
                 };


### PR DESCRIPTION
Example 08:
- Added audio.load() call to ensure canplaythrough event fires
- Set up play overlay click handler immediately on audio load, not after autoplay fails
- Play button now works reliably with click and touch events

Example 23:
- Set up play overlay click handler immediately on audio load
- Refactored event handler setup to be more reliable
- Play button now works reliably with click and touch events

Both visualizers now have functional play buttons that respond immediately to user interaction.