### PR TITLE
Add overview intro lyrics to neural visualizer example

### DIFF
--- a/learning/examples/23-neural-visualizer-2.html
+++ b/learning/examples/23-neural-visualizer-2.html
@@ -301,6 +301,17 @@
         // Lyrics organized in blocks with time slots
         const lyricsBlocks = [
             {
+                type: 'overview',
+                startTime: 0,
+                endTime: 40,
+                lines: [
+                    "[Overview]",
+                    "Avicenna's \"Floating Man\" is a philosophical thought experiment exploring consciousness and self-awareness, questioning whether the soul is distinct from the body.",
+                    "This song voices that thought experiment from the first-person perspective of the floating man.",
+                    "It resonates now, at the dawn of artificial general intelligence, as we grapple with the possibility of untethered consciousness."
+                ]
+            },
+            {
                 type: 'verse1',
                 startTime: 45,
                 endTime: 65,


### PR DESCRIPTION
## Summary
- add an overview lyric block to the neural visualizer example to display context text from 0:00 to 0:40

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912a1ff10948326b139e39297fc0476)