### PR TITLE
Delay AI response by 2 seconds to allow speech to complete

### DIFF
--- a/learning/examples/06-chess-ai.html
+++ b/learning/examples/06-chess-ai.html
@@ -754,7 +754,7 @@
                         this.clearSelection();
 
                         if (!this.gameOver && this.currentPlayer === 'black') {
-                            setTimeout(() => this.makeAIMove(), 500);
+                            setTimeout(() => this.makeAIMove(), 2000);
                         }
                     } else if (piece !== '.' && this.isPlayerPiece(piece)) {
                         this.selectedSquare = [row, col];
@@ -800,7 +800,7 @@
                     this.makeMove(fullMove);
 
                     if (!this.gameOver && this.currentPlayer === 'black') {
-                        setTimeout(() => this.makeAIMove(), 500);
+                        setTimeout(() => this.makeAIMove(), 2000);
                     }
                 }
 


### PR DESCRIPTION
- Increase AI move delay from 500ms to 2000ms
- Gives time for profanity speech to be heard when piece is captured
- Speech starts 800ms after capture, 2s delay ensures it completes