### PR TITLE
Fix workshop exercises script initialization

### DIFF
--- a/learning/workshop-5/data/exercises.js
+++ b/learning/workshop-5/data/exercises.js
@@ -899,4 +899,5 @@ const exercises = [
   }
 ];
 
-export default exercises;
+// Expose exercises to the browser environment
+window.exercises = exercises;


### PR DESCRIPTION
## Summary
- remove the ES module export from the exercises data file to avoid a load-time syntax error
- expose the exercises array on the window so the app logic can access it once the workshop starts

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923bdf0f740832690e5a70c4e1175e4)