### PR TITLE
Fix course selector switching error

### DIFF
--- a/learning/workshops/js/app.js
+++ b/learning/workshops/js/app.js
@@ -126,7 +126,7 @@ async function switchCourse(courseId) {
     }
 
     // Rebuild UI with new course data
-    buildUIFromData();
+    await initializeDynamicUI();
 
     // Load first exercise
     loadExercise(0);


### PR DESCRIPTION
The switchCourse function was calling a non-existent buildUIFromData() function, causing course switches to fail with "failed to switch course" error. Replaced with the correct initializeDynamicUI() function which properly rebuilds the UI elements when switching between courses.